### PR TITLE
fix: moves devcontainer.json to valid markdown

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "Codespaces .NET Core Starter",
   "extensions": [
-    // "coenraads.bracket-pair-colorizer-2",
     "donjayamanne.githistory",
     "eamodio.gitlens",
     "editorconfig.editorconfig",
@@ -15,7 +14,6 @@
     "ms-dotnettools.csharp",
     "ms-vscode.powershell",
     "ms-vsliveshare.vsliveshare",
-    // "vscode-icons-team.vscode-icons",
     "visualstudioexptteam.vscodeintellicode",
     "yzhang.markdown-all-in-one"
   ],


### PR DESCRIPTION
Removes lines with `//`. In JSON, `//` is invalid (there are no comments in JSON, unfortunately) and can potentially cause issues.